### PR TITLE
fix _exit_event.set in __aexit__ coroutine of paginator

### DIFF
--- a/aiocassandra.py
+++ b/aiocassandra.py
@@ -74,7 +74,7 @@ class _Paginator:
         return self
 
     async def __aexit__(self, *exc_info):
-        self._exit_event.set()
+        self._loop.call_soon_threadsafe(self._finish_event.set)
         _len = len(self._deque)
         self._deque.clear()
         logger.debug(


### PR DESCRIPTION
Proposed fix for the `self._exit_event` of paginator not being correctly set when task using paginator cancelled.